### PR TITLE
Delegates death tracking to CHALLENGE_MODE_DEATH_COUNT_UPDATED event

### DIFF
--- a/Core.lua
+++ b/Core.lua
@@ -180,7 +180,6 @@ function GottaGoFaster:CHALLENGE_MODE_DEATH_COUNT_UPDATED()
     GottaGoFaster.UpdateCMObjectives();
   end
 end
-  
 
 function GottaGoFaster:GOSSIP_SHOW()
   if (ggf.inCM == true and ggf.CurrentCM ~= nil and next(ggf.CurrentCM) ~= nil) then

--- a/Core.lua
+++ b/Core.lua
@@ -20,9 +20,10 @@ function GottaGoFaster:OnEnable()
     C_ChatInfo.RegisterAddonMessagePrefix("GottaGoFasterTW");
     self:RegisterEvent("CHALLENGE_MODE_COMPLETED");
     self:RegisterEvent("CHALLENGE_MODE_RESET");
-    self:RegisterEvent("CHALLENGE_MODE_START")
+    self:RegisterEvent("CHALLENGE_MODE_START");
+    self.RegisterEvent("CHALLENGE_MODE_DEATH_COUNT_UPDATED");
     self:RegisterEvent("GOSSIP_SHOW");
-    self:RegisterEvent("PLAYER_ENTERING_WORLD")
+    self:RegisterEvent("PLAYER_ENTERING_WORLD");
     self:RegisterEvent("SCENARIO_POI_UPDATE");
     self:RegisterEvent("WORLD_STATE_TIMER_START");
     self:RegisterEvent("ZONE_CHANGED_NEW_AREA")
@@ -165,12 +166,20 @@ function GottaGoFaster:WORLD_STATE_TIMER_START()
       if (timeCM ~= nil and timeCM <= 2) then
         GottaGoFaster.StartCM(0);
         GottaGoFaster.UpdateCMObjectives();
-      elseif (GottaGoFaster.CurrentCM["Deaths"]) then
-        GottaGoFaster.CurrentCM["Deaths"] = GottaGoFaster.CurrentCM["Deaths"] + 1;
-        GottaGoFaster.UpdateCMObjectives();
-      end
   end
 end
+
+function GottaGoFaster.CHALLENGE_MODE_DEATH_COUNT_UPDATED()
+  GottaGoFaster.Utility.DebugPrint("Death Count Updated")
+  if (ggf.inCM == false or GottaGoFaster.CurrentCM == nil or next(GottaGoFaster.CurrentCM) == nil or GottaGoFaster.CurrentCM["Steps"] == 0) then
+    GottaGoFaster.WhereAmI()
+  end
+  if (ggf.inCM and GottaGoFaster.CurrentCM["Completed"] == false) then
+    GottaGoFaster.CurrentCM["Deaths"] = GottaGoFaster.CurrentCM["Deaths"] + 1;
+    GottaGoFaster.UpdateCMObjectives();
+  end
+end
+  
 
 function GottaGoFaster:GOSSIP_SHOW()
   if (ggf.inCM == true and ggf.CurrentCM ~= nil and next(ggf.CurrentCM) ~= nil) then

--- a/Core.lua
+++ b/Core.lua
@@ -21,7 +21,7 @@ function GottaGoFaster:OnEnable()
     self:RegisterEvent("CHALLENGE_MODE_COMPLETED");
     self:RegisterEvent("CHALLENGE_MODE_RESET");
     self:RegisterEvent("CHALLENGE_MODE_START");
-    self.RegisterEvent("CHALLENGE_MODE_DEATH_COUNT_UPDATED");
+    self:RegisterEvent("CHALLENGE_MODE_DEATH_COUNT_UPDATED");
     self:RegisterEvent("GOSSIP_SHOW");
     self:RegisterEvent("PLAYER_ENTERING_WORLD");
     self:RegisterEvent("SCENARIO_POI_UPDATE");
@@ -166,10 +166,11 @@ function GottaGoFaster:WORLD_STATE_TIMER_START()
       if (timeCM ~= nil and timeCM <= 2) then
         GottaGoFaster.StartCM(0);
         GottaGoFaster.UpdateCMObjectives();
-  end
+      end 
+    end
 end
 
-function GottaGoFaster.CHALLENGE_MODE_DEATH_COUNT_UPDATED()
+function GottaGoFaster:CHALLENGE_MODE_DEATH_COUNT_UPDATED()
   GottaGoFaster.Utility.DebugPrint("Death Count Updated")
   if (ggf.inCM == false or GottaGoFaster.CurrentCM == nil or next(GottaGoFaster.CurrentCM) == nil or GottaGoFaster.CurrentCM["Steps"] == 0) then
     GottaGoFaster.WhereAmI()

--- a/Timer/Utility.lua
+++ b/Timer/Utility.lua
@@ -44,6 +44,7 @@ function GottaGoFaster.SecsToTimeMS(secs)
 end
 
 function GottaGoFaster.CalculateRunTime(startTime, endTime, deaths, corrupt)
+-- TODO Implement Challenger's Peril
   local time = endTime - startTime;
   if (corrupt == false) then
     time = time + (deaths * 5);


### PR DESCRIPTION
Potential fix for [Issue 11](https://github.com/Stinth/GottaGoFaster/issues/11).

Replaces the use of  WORLD_STATE_TIMER_START with CHALLENGE_MODE_DEATH_COUNT_UPDATED to track death events to fix an issue where WORLD_STATE_TIMER_START would no longer fire after a key's timer had depleted.

Unsure if the WhereAmI() function is needed in here, feel free to RM before merge if not.

Adds a small TODO comment in GottaGoFasterHistory death calculation as a reminder further changes will be needed if the affix is to be considered there too.